### PR TITLE
Blacklist some params that would normally require authentication

### DIFF
--- a/config.php.example
+++ b/config.php.example
@@ -14,5 +14,10 @@ $PIWIK_URL = 'http://your-piwik-domain.example.org/piwik/';
 // which you created when you followed instructions above.
 $TOKEN_AUTH = 'xyz';
 
+// By default, only parameter that would work without token_auth at the real piwik are allowed.
+// See Tracking API for more details:
+// http://developer.piwik.org/api-reference/tracking-api
+$allow_override_parameter = false;
+
 // Maximum time, in seconds, to wait for the Piwik server to return the 1*1 GIF
 $timeout = 5;

--- a/piwik.php
+++ b/piwik.php
@@ -36,7 +36,7 @@ if (! isset($timeout)) {
 
 // By default, only parameter that would work without token_auth at the real piwik are allowed.
 if (! isset($allow_override_parameter)) {
-	$allow_override_parameter = false;
+    $allow_override_parameter = false;
 }
 
 function sendHeader($header, $replace = true)
@@ -93,8 +93,8 @@ $url = sprintf("%spiwik.php?cip=%s&token_auth=%s&", $PIWIK_URL, getVisitIp(), $T
 
 $blacklisted_params = array('cip', 'token_auth', 'cdt', 'country', 'region', 'city', 'lat', 'long');
 foreach ($_GET as $key => $value) {
-	if (!in_array($key, $blacklisted_params) || $allow_override_parameter) {
-    	$url .= urlencode($key ). '=' . urlencode($value) . '&';
+    if (!in_array($key, $blacklisted_params) || $allow_override_parameter) {
+        $url .= urlencode($key ). '=' . urlencode($value) . '&';
     }
 }
 sendHeader("Content-Type: image/gif");

--- a/piwik.php
+++ b/piwik.php
@@ -34,6 +34,11 @@ if (! isset($timeout)) {
     $timeout = 5;
 }
 
+// By default, only parameter that would work without token_auth at the real piwik are allowed.
+if (! isset($allow_override_parameter)) {
+	$allow_override_parameter = false;
+}
+
 function sendHeader($header, $replace = true)
 {
     headers_sent() || header($header, $replace);
@@ -86,8 +91,11 @@ if (empty($_GET)) {
 // 2) PIWIK.PHP PROXY: GET parameters found, this is a tracking request, we redirect it to Piwik
 $url = sprintf("%spiwik.php?cip=%s&token_auth=%s&", $PIWIK_URL, getVisitIp(), $TOKEN_AUTH);
 
+$blacklisted_params = array('cip', 'token_auth', 'cdt', 'country', 'region', 'city', 'lat', 'long');
 foreach ($_GET as $key => $value) {
-    $url .= urlencode($key ). '=' . urlencode($value) . '&';
+	if (!in_array($key, $blacklisted_params) || $allow_override_parameter) {
+    	$url .= urlencode($key ). '=' . urlencode($value) . '&';
+    }
 }
 sendHeader("Content-Type: image/gif");
 $stream_options = array('http' => array(

--- a/piwik.php
+++ b/piwik.php
@@ -89,12 +89,18 @@ if (empty($_GET)) {
 @ini_set('magic_quotes_runtime', 0);
 
 // 2) PIWIK.PHP PROXY: GET parameters found, this is a tracking request, we redirect it to Piwik
-$url = sprintf("%spiwik.php?cip=%s&token_auth=%s&", $PIWIK_URL, getVisitIp(), $TOKEN_AUTH);
+if ($_GET['token_auth']) {
+    if (empty($_GET['cip']))
+        $_GET['cip'] = getVisitIp();
+    $url = sprintf("%spiwik.php?%s", $PIWIK_URL, http_build_query($_GET));
+} else {
+    $url = sprintf("%spiwik.php?cip=%s&token_auth=%s&", $PIWIK_URL, getVisitIp(), $TOKEN_AUTH);
 
-$blacklisted_params = array('cip', 'token_auth', 'cdt', 'country', 'region', 'city', 'lat', 'long');
-foreach ($_GET as $key => $value) {
-    if (!in_array($key, $blacklisted_params) || $allow_override_parameter) {
-        $url .= urlencode($key ). '=' . urlencode($value) . '&';
+    $parametersRequireTokenAuth = array('cip', 'token_auth', 'cdt', 'country', 'region', 'city', 'lat', 'long');
+    foreach ($_GET as $key => $value) {
+        if (!in_array($key, $parametersRequireTokenAuth) || $allow_override_parameter) {
+            $url .= urlencode($key ). '=' . urlencode($value) . '&';
+        }
     }
 }
 sendHeader("Content-Type: image/gif");


### PR DESCRIPTION
The Piwik proxy uses authentification to pass on the original IP. This shouldn't be mis-used to allow the other parameters like overriding date or location. 

As there might be uses out there which rely on this, this can be switched off in the config (by turning `$allow_override_parameter` on.)
