### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,17 @@
 language: php
 
-php:
-  - 5.6
-  - 7.3
+matrix:
+    fast_finish: true
+    include:
+      - php: 7.3
+      - php: 7.2
+      - php: 7.1
+      - php: 7.0
+      - php: 5.6
+      - php: 5.5
+        dist: trusty
+      - php: 5.4
+        dist: trusty
 
 before_script:
   - sudo apt-get update
@@ -22,7 +31,7 @@ before_script:
   - composer install --no-progress
 
 script:
-  - phpunit
+  - vendor/bin/phpunit
 
 after_script:
   - sudo cat /var/log/apache2/access.log

--- a/matomo-proxy.php
+++ b/matomo-proxy.php
@@ -33,4 +33,4 @@ if (!(isset($filerequest) && in_array($filerequest, $VALID_FILES))
     exit;
 }
 
-include dirname(__FILE__) . '/proxy.php';
+include __DIR__ . '/proxy.php';

--- a/piwik.php
+++ b/piwik.php
@@ -11,4 +11,4 @@ define('MATOMO_PROXY_FROM_ENDPOINT', 1);
 
 $path = "piwik.php";
 
-include dirname(__FILE__) . '/proxy.php';
+include __DIR__ . '/proxy.php';

--- a/proxy.php
+++ b/proxy.php
@@ -17,8 +17,8 @@ $DEBUG_PROXY = false;
 // set to true if the target matomo server has a ssl certificate that will fail verification, like when testing.
 $NO_VERIFY_SSL = false;
 
-if (file_exists(dirname(__FILE__) . '/config.php')) {
-    include dirname(__FILE__) . '/config.php';
+if (file_exists(__DIR__ . '/config.php')) {
+    include __DIR__ . '/config.php';
 }
 
 // -----
@@ -279,7 +279,7 @@ function getHttpContentAndStatus($url, $timeout, $user_agent)
         $stream_options['http']['header'][] = "Content-type: application/x-www-form-urlencoded";
         $stream_options['http']['header'][] = "Content-Length: " . strlen($postBody);
         $stream_options['http']['content'] = $postBody;
-        
+
         if(!empty($http_ip_forward_header)) {
             $visitIp = getVisitIp();
             $stream_options['http']['header'][] = "$http_ip_forward_header: $visitIp";

--- a/tests/composer.json
+++ b/tests/composer.json
@@ -1,7 +1,7 @@
 {
     "require-dev": {
-        "php": ">=5.3.3",
-        "phpunit/phpunit": "~4.3",
-        "guzzlehttp/guzzle": "~5.0"
+        "php": ">=5.4.0",
+        "phpunit/phpunit": "^4.8.36",
+        "guzzlehttp/guzzle": "^5.0"
     }
 }

--- a/tests/server/index.php
+++ b/tests/server/index.php
@@ -2,4 +2,4 @@
 
 echo "in index.php\n";
 
-include dirname(__FILE__) . '/piwik.php';
+include __DIR__ . '/piwik.php';

--- a/tests/server/plugins/HeatmapSessionRecording/configs.php
+++ b/tests/server/plugins/HeatmapSessionRecording/configs.php
@@ -2,4 +2,4 @@
 
 echo "in plugins/HeatmapSessionRecording/configs.php\n";
 
-include dirname(__FILE__) . '/../../piwik.php';
+include __DIR__ . '/../../piwik.php';


### PR DESCRIPTION
# Changed log
- Removing `php-5.3` test because this PHP version is so old that this is hard to do test.
- The `shell_exec` is not appropriate. Using the `rename` function instead.
- To support latest stable `PHPUnit` version, using the final `4.8.36` version to be easy to migrate future `PHPUnit` version.
- Using the `PHPUnit\Framework\TestCase` class to be compatible with future `PHPUnit` version.
- The `dirname(__FILE__)` is equivalent to the `__DIR__`. Using the `__DIR__` instead.