### PR TITLE
rename piwik -> matomo

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,34 +30,34 @@ In your Matomo server:
 
 You need to install the proxy on the server where your websites are hosted. You can do it both ways:
 
-- download [`piwik.php`](https://raw.githubusercontent.com/matomo-org/tracker-proxy/master/piwik.php), [`proxy.php`](https://raw.githubusercontent.com/matomo-org/tracker-proxy/master/proxy.php), [`matomo-proxy.php`](https://raw.githubusercontent.com/matomo-org/tracker-proxy/master/matomo-proxy.php), [`plugins/HeatmapSessionRecording/configs.php`](https://raw.githubusercontent.com/matomo-org/tracker-proxy/master/plugins/HeatmapSessionRecording/configs.php)
+- download the files manually
 - or install the whole repository with git
 
-#### Manual download of `piwik.php`
+#### Manual download of `matomo.php`
 
-- download [`piwik.php`](https://raw.githubusercontent.com/matomo-org/tracker-proxy/master/piwik.php), [`proxy.php`](https://raw.githubusercontent.com/matomo-org/tracker-proxy/master/proxy.php), [`matomo-proxy.php`](https://raw.githubusercontent.com/matomo-org/tracker-proxy/master/matomo-proxy.php) & [`plugins/HeatmapSessionRecording/configs.php`](https://raw.githubusercontent.com/matomo-org/tracker-proxy/master/plugins/HeatmapSessionRecording/configs.php)
-  to your website root directory, for example at http://trackedsite.com/piwik.php, http://trackedsite.com/proxy.php, http://trackedsite.com/matomo-proxy.php & http://trackedsite.com/plugins/HeatmapSessionRecording/configs.php
+- download [`matomo.php`](https://raw.githubusercontent.com/matomo-org/tracker-proxy/master/matomo.php), download [`piwik.php`](https://raw.githubusercontent.com/matomo-org/tracker-proxy/master/piwik.php), [`proxy.php`](https://raw.githubusercontent.com/matomo-org/tracker-proxy/master/proxy.php), [`matomo-proxy.php`](https://raw.githubusercontent.com/matomo-org/tracker-proxy/master/matomo-proxy.php) & [`plugins/HeatmapSessionRecording/configs.php`](https://raw.githubusercontent.com/matomo-org/tracker-proxy/master/plugins/HeatmapSessionRecording/configs.php)
+  to your website root directory, for example at http://trackedsite.com/matomo.php, http://trackedsite.com/piwik.php, http://trackedsite.com/proxy.php, http://trackedsite.com/matomo-proxy.php & http://trackedsite.com/plugins/HeatmapSessionRecording/configs.php
 - edit the file to set the configuration variables:
-    - `$PIWIK_URL` should contain the URL to your Matomo server
+    - `$MATOMO_URL` should contain the URL to your Matomo server
     - `$PROXY_URL` should contain the URL to the tracker-proxy server
     - `$TOKEN_AUTH` should contain the `token_auth`
 
 #### With git
 
-- clone the repository: `git clone https://github.com/matomo-org/tracker-proxy.git matomo` into your website root directory (for example at http://trackedsite.com/matomo/piwik.php)
+- clone the repository: `git clone https://github.com/matomo-org/tracker-proxy.git matomo` into your website root directory (for example at http://trackedsite.com/matomo/matomo.php)
 - copy the configuration template: `cp config.php.example config.php`
 - change the configuration in the newly created `config.php`:
-    - `$PIWIK_URL` should contain the URL to your Matomo server
+    - `$MATOMO_URL` should contain the URL to your Matomo server
     - `$PROXY_URL` should contain the URL to the tracker-proxy server
     - `$TOKEN_AUTH` should contain the `token_auth`
 
 By using git you will later be able to update by simply running `git pull`.
 
-Be aware that with this method, `piwik.php` and other files are in a `matomo/` subdirectory. Keep that in mind when applying the instructions for the next step.
+Be aware that with this method, `matomo.php` and other files are in a `matomo/` subdirectory. Keep that in mind when applying the instructions for the next step.
 
 ### 3. Use the proxy in the Javascript tracker
 
-The proxy file (http://trackedsite.com/piwik.php) will be called by the Matomo Javascript tracker instead of calling directly the (secret) Matomo server (http://your-matomo-domain.example.org/matomo/).
+The proxy file (http://trackedsite.com/matomo.php) will be called by the Matomo Javascript tracker instead of calling directly the (secret) Matomo server (http://your-matomo-domain.example.org/matomo/).
 
 To achieve this, change the Matomo Javascript Code that is in the footer of your pages:
 
@@ -68,10 +68,10 @@ To achieve this, change the Matomo Javascript Code that is in the footer of your
     [...]
     (function() {
         var u="//trackedsite.com/";
-        _paq.push(["setTrackerUrl", u+"piwik.php"]);
+        _paq.push(["setTrackerUrl", u+"matomo.php"]);
         _paq.push(["setSiteId", "trackedsite-id"]);
         var d=document, g=d.createElement("script"), s=d.getElementsByTagName("script")[0];
-        g.type="text/javascript"; g.async=true; g.defer=true; g.src=u+"piwik.php"; s.parentNode.insertBefore(g,s);
+        g.type="text/javascript"; g.async=true; g.defer=true; g.src=u+"matomo.php"; s.parentNode.insertBefore(g,s);
     })();
     </script>
     <!-- End Matomo Code -->
@@ -80,13 +80,13 @@ To achieve this, change the Matomo Javascript Code that is in the footer of your
     What has changed in this code snippet compared to the normal Matomo code?
 
     - the secret Matomo URL is now replaced by your website URL (the proxy)
-    - `piwik.js` becomes `piwik.php` (or `matomo/piwik.php` if you used the *git* method): piwik.php is the proxy script
+    - `matomo.js` becomes `matomo.php` (or `matomo/matomo.php` if you used the *git* method): matomo.php is the proxy script
     - the `<noscript>` part of the code at the end is removed, since it is not currently used by Matomo, and it contains the (secret) Matomo URL which you want to hide
     - make sure to replace `trackedsite-id` with your idsite
 
 - paste the modified Matomo Javascript code in the pages you wish to track.
 
-This modified Javascript code will then track visits/pages/conversions by calling `trackedsite.com/piwik.php`, which will then automatically call your (hidden) Matomo Server URL.
+This modified Javascript code will then track visits/pages/conversions by calling `trackedsite.com/matomo.php`, which will then automatically call your (hidden) Matomo Server URL.
 
 At this stage, example.com should be tracked by your Matomo without showing the Matomo server URL. Repeat the step 3. for each website you wish to track in Matomo.
 
@@ -101,12 +101,12 @@ _Note: you can get the opt out iframe from inside the Administration > Privacy >
 
 ### Timeout
 
-By default, the `piwik.php` proxy will wait 5 seconds for the Matomo server to return the response. 
+By default, the `matomo.php` proxy will wait 5 seconds for the Matomo server to return the response. 
 You may change this timeout by editing the `$timeout` value in `config.php`.
  
 ### User-Agent
  
-By default, the `piwik.php` proxy will contact your Matomo server with the User-Agent of the client requesting `piwik.php`. 
+By default, the `matomo.php` proxy will contact your Matomo server with the User-Agent of the client requesting `matomo.php`. 
 You may force the proxy script to use a particular User-Agent by  editing the `$user_agent` value in `config.php`.
 
 ## Contributing
@@ -119,7 +119,7 @@ Before running the tests, create a config.php file w/ the following contents in 
 
 ```
 <?php
-$PIWIK_URL = 'http://localhost/tests/server/';
+$MATOMO_URL = 'http://localhost/tests/server/';
 $TOKEN_AUTH = 'xyz';
 $timeout = 5;
 ```

--- a/config.php.example
+++ b/config.php.example
@@ -8,7 +8,7 @@
 // Edit the line below, and replace http://your-matomo-domain.example.org/matomo/
 // with your Matomo URL ending with a slash.
 // This URL will never be revealed to visitors or search engines.
-$PIWIK_URL = 'http://your-matomo-domain.example.org/matomo/';
+$MATOMO_URL = 'http://your-matomo-domain.example.org/matomo/';
 
 // Edit the line below and replace http://your-tracker-proxy.org/ with the URL to your tracker-proxy
 // setup. This URL will be used in Matomo output that contains the Matomo URL, so your Matomo is effectively
@@ -22,7 +22,7 @@ $TOKEN_AUTH = 'xyz';
 // Maximum time, in seconds, to wait for the Matomo server to return the 1*1 GIF
 $timeout = 5;
 
-// By default, the HTTP User Agent will be set to the user agent of the client requesting piwik.php
+// By default, the HTTP User Agent will be set to the user agent of the client requesting matomo.php
 // Edit the line below to force the proxy to always use a specific user agent string.
 $user_agent = '';
 

--- a/matomo.php
+++ b/matomo.php
@@ -9,6 +9,6 @@
 
 define('MATOMO_PROXY_FROM_ENDPOINT', 1);
 
-$path = "piwik.php";
+$path = "matomo.php";
 
 include __DIR__ . '/proxy.php';

--- a/proxy.php
+++ b/proxy.php
@@ -86,7 +86,12 @@ if ((empty($_GET) && empty($_POST)) || (isset($filerequest) && substr($filereque
 
         // Silent fail: hide Warning in 'matomo.js' response
         if (empty($_GET) && empty($_POST)) {
-            list($content, $httpStatus) = getHttpContentAndStatus($MATOMO_URL . 'matomo.js', $timeout, $user_agent);
+            if ($path !== 'matomo.php') {
+                $jsPath = 'piwik.js'; // for BC eg in case user uses an older version of Matomo
+            } else {
+                $jsPath = 'matomo.js';
+            }
+            list($content, $httpStatus) = getHttpContentAndStatus($MATOMO_URL . $jsPath, $timeout, $user_agent);
         } else {
             list($content, $httpStatus) = getHttpContentAndStatus($MATOMO_URL . $filerequest, $timeout, $user_agent);
         }

--- a/proxy.php
+++ b/proxy.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Piwik - free/libre analytics platform
- * Piwik Proxy Hide URL
+ * Matomo - free/libre analytics platform
+ * Matomo Proxy Hide URL
  *
- * @link http://piwik.org/faq/how-to/#faq_132
+ * @link https://matomo.org/faq/how-to/#faq_132
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
@@ -23,14 +23,18 @@ if (file_exists(__DIR__ . '/config.php')) {
 
 // -----
 // Important: read the instructions in README.md or at:
-// https://github.com/piwik/tracker-proxy#piwik-tracker-proxy
+// https://github.com/matomo-org/tracker-proxy#matomo-tracker-proxy
 // -----
+if (! isset($MATOMO_URL) && isset($PIWIK_URL)) {
+    // FOR BC
+    $MATOMO_URL = $PIWIK_URL;
+}
 
-// Edit the line below, and replace http://your-piwik-domain.example.org/piwik/
-// with your Piwik URL ending with a slash.
+// Edit the line below, and replace http://your-matomo-domain.example.org/matomo/
+// with your Matomo URL ending with a slash.
 // This URL will never be revealed to visitors or search engines.
-if (! isset($PIWIK_URL)) {
-    $PIWIK_URL = 'http://your-piwik-domain.example.org/piwik/';
+if (! isset($MATOMO_URL)) {
+    $MATOMO_URL = 'http://your-matomo-domain.example.org/matomo/';
 }
 
 // Edit the line below, and replace xyz by the token_auth for the user "UserTrackingAPI"
@@ -39,12 +43,12 @@ if (! isset($TOKEN_AUTH)) {
     $TOKEN_AUTH = 'xyz';
 }
 
-// Maximum time, in seconds, to wait for the Piwik server to return the 1*1 GIF
+// Maximum time, in seconds, to wait for the Matomo server to return the 1*1 GIF
 if (! isset($timeout)) {
     $timeout = 5;
 }
 
-// The HTTP User-Agent to set in the request sent to Piwik Tracking API
+// The HTTP User-Agent to set in the request sent to Matomo Tracking API
 if (empty($user_agent)) {
     $user_agent = arrayValue($_SERVER, 'HTTP_USER_AGENT', '');
 }
@@ -56,7 +60,7 @@ if (empty($user_agent)) {
 // the HTTP response headers captured via fopen or curl
 $httpResponseHeaders = array();
 
-// 1) PIWIK.JS PROXY: No _GET parameter, we serve the JS file; or we serve a requested js file
+// 1) MATOMO.JS PROXY: No _GET parameter, we serve the JS file; or we serve a requested js file
 if ((empty($_GET) && empty($_POST)) || (isset($filerequest) && substr($filerequest, -3) === '.js')) {
     $modifiedSince = false;
     if (isset($_SERVER['HTTP_IF_MODIFIED_SINCE'])) {
@@ -67,7 +71,7 @@ if ((empty($_GET) && empty($_POST)) || (isset($filerequest) && substr($filereque
         }
         $modifiedSince = strtotime($modifiedSince);
     }
-    // Re-download the piwik.js once a day maximum
+    // Re-download the matomo.js once a day maximum
     $lastModified = time() - 86400;
 
     // set HTTP response headers
@@ -80,36 +84,36 @@ if ((empty($_GET) && empty($_POST)) || (isset($filerequest) && substr($filereque
         sendHeader('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
         sendHeader('Content-Type: application/javascript; charset=UTF-8');
 
-        // Silent fail: hide Warning in 'piwik.js' response
+        // Silent fail: hide Warning in 'matomo.js' response
         if (empty($_GET) && empty($_POST)) {
-            list($content, $httpStatus) = getHttpContentAndStatus($PIWIK_URL . 'piwik.js', $timeout, $user_agent);
+            list($content, $httpStatus) = getHttpContentAndStatus($MATOMO_URL . 'matomo.js', $timeout, $user_agent);
         } else {
-            list($content, $httpStatus) = getHttpContentAndStatus($PIWIK_URL . $filerequest, $timeout, $user_agent);
+            list($content, $httpStatus) = getHttpContentAndStatus($MATOMO_URL . $filerequest, $timeout, $user_agent);
         }
-        if ($piwikJs = $content) {
-            echo $piwikJs;
+        if ($matomoJs = $content) {
+            echo $matomoJs;
         } else {
-            echo '/* there was an error loading piwik.js */';
+            echo '/* there was an error loading matomo.js */';
         }
     }
     exit;
 }
 @ini_set('magic_quotes_runtime', 0);
 
-// 2) PIWIK.PHP PROXY: GET parameters found, this is a tracking request, we redirect it to Piwik
+// 2) MATOMO.PHP PROXY: GET parameters found, this is a tracking request, we redirect it to Piwik
 if (strpos($path, '?') === false) {
     $path = $path . '?';
 }
 
 $extraQueryParams = array();
-if (strpos($path, 'piwik.php') === 0) {
+if (strpos($path, 'piwik.php') === 0 || strpos($path, 'matomo.php') === 0) {
     $extraQueryParams = array(
         'cip' => getVisitIp(),
         'token_auth' => $TOKEN_AUTH,
     );
 }
 
-$url = $PIWIK_URL . $path;
+$url = $MATOMO_URL . $path;
 $url .= http_build_query(array_merge($extraQueryParams, $_GET));
 
 if (version_compare(PHP_VERSION, '5.3.0', '<')) {
@@ -140,15 +144,15 @@ if (version_compare(PHP_VERSION, '5.3.0', '<')) {
 function sanitizeContent($content)
 {
     global $TOKEN_AUTH;
-    global $PIWIK_URL;
+    global $MATOMO_URL;
     global $PROXY_URL;
     global $VALID_FILES;
 
-    $matomoHost = parse_url($PIWIK_URL, PHP_URL_HOST);
+    $matomoHost = parse_url($MATOMO_URL, PHP_URL_HOST);
     $proxyHost = parse_url($PROXY_URL, PHP_URL_HOST);
 
     $content = str_replace($TOKEN_AUTH, '<token>', $content);
-    $content = str_replace($PIWIK_URL, $PROXY_URL, $content);
+    $content = str_replace($MATOMO_URL, $PROXY_URL, $content);
     $content = str_replace($matomoHost, $proxyHost, $content);
 
     if(isset($VALID_FILES)) {

--- a/tests/server/index.php
+++ b/tests/server/index.php
@@ -2,4 +2,4 @@
 
 echo "in index.php\n";
 
-include __DIR__ . '/piwik.php';
+include __DIR__ . '/matomo.php';

--- a/tests/server/matomo.js
+++ b/tests/server/matomo.js
@@ -1,0 +1,1 @@
+this is matomo.js

--- a/tests/server/matomo.php
+++ b/tests/server/matomo.php
@@ -28,9 +28,9 @@ if (!empty($headers)) {
 }
 
 if (!empty($_GET['debug'])) {
-    $host = parse_url($PIWIK_URL, PHP_URL_HOST);
+    $host = parse_url($MATOMO_URL, PHP_URL_HOST);
     echo "\nHOST: $host\n";
-    echo "URL: $PIWIK_URL\n";
+    echo "URL: $MATOMO_URL\n";
     echo "TOKEN_AUTH: $TOKEN_AUTH\n";
 }
 

--- a/tests/server/piwik.js
+++ b/tests/server/piwik.js
@@ -1,1 +1,0 @@
-this is piwik.js

--- a/tests/server/plugins/HeatmapSessionRecording/configs.php
+++ b/tests/server/plugins/HeatmapSessionRecording/configs.php
@@ -2,4 +2,4 @@
 
 echo "in plugins/HeatmapSessionRecording/configs.php\n";
 
-include __DIR__ . '/../../piwik.php';
+include __DIR__ . '/../../matomo.php';

--- a/tests/travis/config.php
+++ b/tests/travis/config.php
@@ -1,6 +1,5 @@
 <?php
-
-$PIWIK_URL = 'http://localhost/tests/server/';
+$MATOMO_URL = 'http://localhost/tests/server/';
 
 $PROXY_URL = 'http://proxy/';
 


### PR DESCRIPTION
refs https://github.com/matomo-org/matomo/issues/12420

should be backwards compatible and not really change anything. Eg we still read `$PIWIK_URL` from config. 