### PR TITLE
Enable and save log file when DEBUG_PROXY is enabled

### DIFF
--- a/proxy.php
+++ b/proxy.php
@@ -14,6 +14,13 @@ if (!defined('MATOMO_PROXY_FROM_ENDPOINT')) {
 // if set to true, will print out more information about request errors so said errors can be more easily debugged.
 $DEBUG_PROXY = false;
 
+if( $DEBUG_PROXY ){
+    error_reporting( E_ALL );
+    ini_set( 'log_errors', 1 );
+    ini_set( 'display_errors', 1 );
+    ini_set( 'error_log', __DIR__ . '/debug-proxy.log' );
+}
+
 // set to true if the target matomo server has a ssl certificate that will fail verification, like when testing.
 $NO_VERIFY_SSL = false;
 


### PR DESCRIPTION
I some case error_log is disabled on server level, and If you enable DEBUG_PROXY no log message are write, appear only "there was an error loading matomo.js" message.
Also, for example, when using WordPress and WP_DEBUG is enabled, on debug.log nothing entry are write, because script js call matomo.php directly, and WordPress don't run. I think this scenario are reproducible with other CMS.