### PR TITLE
Update # FAQ Links

### DIFF
--- a/matomo.php
+++ b/matomo.php
@@ -3,7 +3,7 @@
  * Matomo - free/libre analytics platform
  * Matomo Proxy Hide URL
  *
- * @link https://matomo.org/faq/how-to/#faq_132
+ * @link https://matomo.org/faq/how-to/faq_132
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 

--- a/piwik.php
+++ b/piwik.php
@@ -3,7 +3,7 @@
  * Matomo - free/libre analytics platform
  * Matomo Proxy Hide URL
  *
- * @link https://matomo.org/faq/how-to/#faq_132
+ * @link https://matomo.org/faq/how-to/faq_132
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 

--- a/proxy.php
+++ b/proxy.php
@@ -3,7 +3,7 @@
  * Matomo - free/libre analytics platform
  * Matomo Proxy Hide URL
  *
- * @link https://matomo.org/faq/how-to/#faq_132
+ * @link https://matomo.org/faq/how-to/faq_132
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 


### PR DESCRIPTION
A recent knowledge base update has changed how FAQ links work on matomo.org

Links with `#` in the link no longer work for guides or FAQs
