### PR TITLE
added JS option to $SUPPORTED_METHODS in opt out

### DIFF
--- a/matomo-proxy.php
+++ b/matomo-proxy.php
@@ -5,7 +5,8 @@ define('MATOMO_PROXY_FROM_ENDPOINT', 1);
 $path = 'index.php';
 
 $SUPPORTED_METHODS = [
-    'CoreAdminHome.optOut'
+    'CoreAdminHome.optOut',
+	'CoreAdminHome.optOutJS'
 ];
 $VALID_FILES = [
     'plugins/CoreAdminHome/javascripts/optOut.js'


### PR DESCRIPTION
### Description:

Hello,

Matomo changed the opt out from iFrame to JS, see  https://github.com/matomo-org/matomo/issues/17452

So the full URI has to look like this: /matomo-proxy.php?module=CoreAdminHome&action=optOut**JS**&divId=matomo-opt-out&language=auto&showIntro=1
But in `matomo-proxy.php`, only `optOut` is in the list of allowed methods. `optOutJS` has to be added or the file returns an error 404. Now both methods are supported.



### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
